### PR TITLE
Fix newly enforced package:pedantic lints

### DIFF
--- a/lib/src/clock.dart
+++ b/lib/src/clock.dart
@@ -16,5 +16,5 @@ const _zoneKey = #timing_Clock;
 DateTime now() => (Zone.current[_zoneKey] as _Clock ?? _defaultClock)();
 
 /// Runs [f], with [clock] scoped whenever [now] is called.
-T scopeClock<T>(DateTime clock(), T f()) =>
+T scopeClock<T>(DateTime Function() clock, T Function() f) =>
     runZoned(f, zoneValues: {_zoneKey: clock});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,8 @@
 name: timing
-version: 0.1.1+2
+version: 0.1.1+3-dev
 description: >-
   A simple package for tracking the performance of synchronous and asynchronous
   actions.
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/timing
 
 environment:

--- a/test/timing_test.dart
+++ b/test/timing_test.dart
@@ -20,13 +20,14 @@ void main() {
   TimeTracker tracker;
   TimeTracker nestedTracker;
 
-  T scopedTrack<T>(T f()) => scopeClock(fakeClock, () => tracker.track(f));
+  T scopedTrack<T>(T Function() f) =>
+      scopeClock(fakeClock, () => tracker.track(f));
 
   setUp(() {
     time = startTime;
   });
 
-  void canHandleSync([additionalExpects() = _noop]) {
+  void canHandleSync([void Function() additionalExpects = _noop]) {
     test('Can track sync code', () {
       expect(tracker.isStarted, false);
       expect(tracker.isTracking, false);
@@ -94,7 +95,7 @@ void main() {
     });
   }
 
-  void canHandleAsync([additionalExpects() = _noop]) {
+  void canHandleAsync([void Function() additionalExpects = _noop]) {
     test('Can track async code', () async {
       expect(tracker.isStarted, false);
       expect(tracker.isTracking, false);


### PR DESCRIPTION
- use_function_type_syntax_for_parameters

Drop author field from pubspec